### PR TITLE
auto-deploy from dev branch

### DIFF
--- a/custom_components/tetraconnect/com_manager.py
+++ b/custom_components/tetraconnect/com_manager.py
@@ -200,41 +200,9 @@ class COMManager:
                     resp.decode("utf-8").strip().replace("\r\n", ""),
                 )
 
-        # parse service commands
-        # self._parse_tetra_service_commands(raw_data)
-
         _LOGGER.info(
             "##### TETRA services initialized successfully on %s #####", self.com_port
         )
-
-    # def _parse_tetra_service_commands(self, raw_data) -> None:
-    #     """Parse the initial response to extract manufacturer, device ID, and revision."""
-
-    #     for cmd, resp in raw_data.items():
-    #         # init defaults
-    #         for key, default in TETRA_DEFAULTS.items():
-    #             self._tetra_defaults[key] = default
-    #         parsed_data = {}
-
-    #         self._tetra_defaults["tetra_command"] = (
-    #             cmd.strip().replace("\r\n", "").replace("AT+", "").split("=")[0]
-    #         )
-    #         self._tetra_defaults["tetra_message"] = (
-    #             cmd.strip().replace("\r\n", "").split("=")[1] if "=" in cmd else ""
-    #         )
-    #         resp = resp.decode("utf-8").strip()
-    #         parsed_data = {
-    #             self._tetra_defaults["tetra_command"]: self._tetra_defaults[
-    #                 "tetra_message"
-    #             ],
-    #             "Status": resp,
-    #         }
-    #         self.helpers.update_entities(parsed_data)
-    #         _LOGGER.debug(
-    #             "Parsed TETRA command: %s with response: %s",
-    #             self._tetra_defaults["tetra_command"],
-    #             resp,
-    #         )
 
 
 class SerialHandler(asyncio.Protocol):

--- a/custom_components/tetraconnect/const.py
+++ b/custom_components/tetraconnect/const.py
@@ -9,16 +9,17 @@ MANUFACTURERS_LIST = ["Motorola"]
 SLEEP_TIME_CONNECTION_CHECK = 10  # Sleep time in seconds between connection checks
 MAX_RETRY_ATTEMPTS = 5  # Maximum number of attempts to connect to the device
 SLEEP_TIME_RETRY = 5  # Sleep time in seconds between retries
-
+BAUDRATE = 38400
 TETRA_DEFAULTS: dict[str, object] = {
     # general
     "tetra_command": "",
     "tetra_command_desc": "",
     "tetra_content": "",
 }
+MQTT_TOPIC_DEFAULT = "tetraconnect"
+
 
 # Motorola specific constants
-BAUDRATE = 38400
 MOTOROLA_COMMANDS: dict[str, str] = {
     "+CTSDSR": "multi",
     "+GMM": "single",

--- a/custom_components/tetraconnect/helpers.py
+++ b/custom_components/tetraconnect/helpers.py
@@ -60,9 +60,11 @@ class TetraconnectHelpers:
 
         try:
             # Only include keys with non-empty, non-None, non-zero values
-            message: dict[str, str] = {
-                k: v for k, v in data_dict.items() if v not in ("", 0, None)
-            }
+            # message: dict[str, str] = {
+            #     k: v for k, v in data_dict.items() if v not in ("", 0, None)
+            # }
+
+            message: dict[str, str] = dict(data_dict)
 
             if next(iter(message), None) != "sds_command":
                 first_key = next(iter(message), None)

--- a/custom_components/tetraconnect/tranlations/de.json
+++ b/custom_components/tetraconnect/tranlations/de.json
@@ -1,0 +1,24 @@
+{
+  "title": "tetraconnect",
+  "config": {
+      "step": {
+          "user": {
+            "title": "Einrichtung von tetraconnect",
+            "description": "Bitte wähle den Hersteller des Funkgerätes. Wähle anschließend die Baudrate sowie den seriellen Port aus.",
+            "menu_options": {
+              "manufacturer": "Hersteller",
+              "serial_port": "Serieller Port",
+              "baudrate": "Baudrate",
+              "mqtt": "Eingehende Daten via MQTT veröffentlichen?",
+              "topic": "Topic"
+            }
+      },
+      "error": {
+        "timeout_error": "Angeschlossenes Gerät antwortet nicht.",
+        "serial_error": "Fehler beim Zugriff auf den seriellen Port.",
+        "manufacturer_mismatch": "Gerät meldet einen anderen Hersteller als der ausgewählte.",
+        "unknown": "Unbekannter Fehler"
+      }
+    }
+  }
+}


### PR DESCRIPTION
implemented german tranlsation
changed data handling: all values - even "0", "none" or empty strings - are now stored in the database
implemented config_flow for MQTT publishing - config has no effect right now!